### PR TITLE
Update api methods

### DIFF
--- a/methods.js
+++ b/methods.js
@@ -22,12 +22,18 @@ module.exports = {
     async: {
       get: require('./ritual/async/get'),
       publish: require('./ritual/async/publish')
+    },
+    pull: {
+      mine: require('./ritual/pull/mine')
     }
   },
   shard: {
     async: {
       get: require('./shard/async/get'),
       publishAll: require('./shard/async/publishAll')
+    },
+    pull: {
+      byRoot: require('./shard/pull/byRoot')
     }
   },
   share: {

--- a/methods.js
+++ b/methods.js
@@ -14,7 +14,7 @@ module.exports = {
       publish: require('./root/async/publish')
     },
     pull: {
-      roots: require('./root/pull/roots'),
+      mine: require('./root/pull/mine'),
       backlinks: require('./root/pull/backlinks')
     }
   },

--- a/root/pull/mine.js
+++ b/root/pull/mine.js
@@ -3,7 +3,7 @@ const next = require('pull-next-query')
 const { isRoot } = require('ssb-dark-crystal-schema')
 
 module.exports = function (server) {
-  return function pullRoots (opts = {}) {
+  return function mine (opts = {}) {
     const query = [{
       $filter: {
         value: {


### PR DESCRIPTION
Check `root.pull.roots` to `root.pull.mine`, clearer language, also same as `ritual.pull.mine`. Also added `shard.pull.byRoot` for use in patchbay-dark-crystal