### PR TITLE
add validators which skip injection

### DIFF
--- a/isRitual.js
+++ b/isRitual.js
@@ -1,0 +1,1 @@
+module.exports = require('ssb-dark-crystal-schema').isRitual

--- a/isRoot.js
+++ b/isRoot.js
@@ -1,0 +1,1 @@
+module.exports = require('ssb-dark-crystal-schema').isRoot

--- a/isShard.js
+++ b/isShard.js
@@ -1,0 +1,1 @@
+module.exports = require('ssb-dark-crystal-schema').isShard


### PR DESCRIPTION
at the moment to use `isRoot` I have to instantiate scuttle-dc, which I can't always do if I don't have a nice server object around.

This means I can go `require('scuttle-dark-crystal/isRoot')` and shazam!