### PR TITLE
Indentify secret

### DIFF
--- a/isReply.js
+++ b/isReply.js
@@ -1,17 +1,8 @@
 const isReply = require('scuttle-invite/isReply')
 const getContent = require('ssb-msg-content')
-const secrets = require('secrets.js-grempe')
+const { validateShard } = require('./secretsWrapper')
 
 module.exports = function (msg) {
-  return isReply(msg) && validateShard(msg)
-}
-
-function validateShard (possibleReply) {
-  const shard = getContent(possibleReply).body
-  try {
-    secrets.extractShareComponents(shard)
-  } catch (err) {
-    return false
-  }
-  return true
+  const msgContent = getContent(msg).body
+  return isReply(msg) && validateShard(msgContent)
 }

--- a/recover/async/recombine.js
+++ b/recover/async/recombine.js
@@ -1,8 +1,7 @@
 const pull = require('pull-stream')
 const ref = require('ssb-ref')
-const secrets = require('secrets.js-grempe')
+const secrets = require('../../secretsWrapper')
 const getContent = require('ssb-msg-content')
-const crypto = require('crypto')
 
 const isReply = require('../../isReply')
 
@@ -61,12 +60,7 @@ module.exports = function (server) {
               return callback(new Error(errorMsg))
             }
             try {
-              const hex = secrets.combine(shards)
-              const hashOfSecret = hex.slice(-40)
-              var secret = secrets.hex2str(hex.slice(0, -40))
-              if (crypto.createHash('sha1').update(secret, 'binary').digest('hex') !== hashOfSecret) {
-                throw new Error('This does not look like a secret')
-              }
+              var secret = secrets.combine(shards)
             } catch (err) {
               return callback(err)
             }

--- a/recover/async/recombine.js
+++ b/recover/async/recombine.js
@@ -2,6 +2,8 @@ const pull = require('pull-stream')
 const ref = require('ssb-ref')
 const secrets = require('secrets.js-grempe')
 const getContent = require('ssb-msg-content')
+const crypto = require('crypto')
+
 const isReply = require('../../isReply')
 
 // const pullRitual = require('../../ritual/pull/mine')
@@ -59,8 +61,12 @@ module.exports = function (server) {
               return callback(new Error(errorMsg))
             }
             try {
-              var hex = secrets.combine(shards)
-              var secret = secrets.hex2str(hex)
+              const hex = secrets.combine(shards)
+              const hashOfSecret = hex.slice(-40)
+              var secret = secrets.hex2str(hex.slice(0, -40))
+              if (crypto.createHash('sha1').update(secret, 'binary').digest('hex') !== hashOfSecret) {
+                throw new Error('This does not look like a secret')
+              }
             } catch (err) {
               return callback(err)
             }

--- a/secretsWrapper.js
+++ b/secretsWrapper.js
@@ -1,0 +1,22 @@
+const secrets = require('secrets.js-grempe')
+const crypto = require('crypto')
+
+module.exports = {
+  share: function (secret, numOfShards, quorum) {
+    const hexSecret = secrets.str2hex(secret)
+    const hashOfSecret = crypto.createHash('sha1').update(secret, 'binary').digest('hex')
+    return secrets.share(hexSecret + hashOfSecret, numOfShards, quorum)
+  },
+
+  combine: function (shards) {
+    // this could probably be improved by checking the hash before converting to hex
+    const hex = secrets.combine(shards)
+    const hashOfSecret = hex.slice(-40)
+    var secret = secrets.hex2str(hex.slice(0, -40))
+    if (crypto.createHash('sha1').update(secret, 'binary').digest('hex') !== hashOfSecret) {
+      throw new Error('This does not look like a secret')
+    } else {
+      return secret
+    }
+  }
+}

--- a/secretsWrapper.js
+++ b/secretsWrapper.js
@@ -1,28 +1,30 @@
 const secrets = require('secrets.js-grempe')
 const crypto = require('crypto')
 
+const packShard = shard => {
+  const shardData = shard.slice(3)
+  const shardDataBase64 = Buffer.from(shardData, 'hex').toString('base64')
+  return shard.slice(0, 3) + shardDataBase64
+}
+
+const unpackShard = shard => {
+  const shardData = shard.slice(3)
+  const shardDataHex = Buffer.from(shardData, 'base64').toString('hex')
+  return shard.slice(0, 3) + shardDataHex
+}
+
 module.exports = {
   share: function (secret, numOfShards, quorum) {
     const hexSecret = secrets.str2hex(secret)
     const hashOfSecret = crypto.createHash('sha1').update(secret, 'binary').digest('hex')
     const shardsHex = secrets.share(hexSecret + hashOfSecret, numOfShards, quorum)
-  
-    const shardsBase64 = shardsHex.map(shard => {
-      const shardData = shard.slice(3)
-      const shardDataBase64 = Buffer.from(shardData, 'hex').toString('base64')
-      return shard.slice(0,3) + shardDataBase64
-    })
-    console.log('IN', shardsBase64)
-    console.log(shardsHex[0].length, shardsBase64[0].length)
+
+    const shardsBase64 = shardsHex.map(packShard)
     return shardsBase64
   },
 
   combine: function (shardsBase64) {
-    const shards = shardsBase64.map(shard => {
-      const shardData = shard.slice(3)
-      const shardDataHex = Buffer.from(shardData, 'base64').toString('hex')
-      return shard.slice(0,3) + shardDataHex
-    })
+    const shards = shardsBase64.map(unpackShard)
     // this could probably be improved by checking the hash before converting to hex
     const hex = secrets.combine(shards)
     const hashOfSecret = hex.slice(-40)
@@ -34,7 +36,7 @@ module.exports = {
     }
   },
   validateShard: function (shardBase64) {
-    const shard = Buffer.from(shardBase64, 'base64').toString('utf8')
+    const shard = unpackShard(shardBase64)
     try {
       secrets.extractShareComponents(shard)
     } catch (err) {

--- a/secretsWrapper.js
+++ b/secretsWrapper.js
@@ -5,10 +5,12 @@ module.exports = {
   share: function (secret, numOfShards, quorum) {
     const hexSecret = secrets.str2hex(secret)
     const hashOfSecret = crypto.createHash('sha1').update(secret, 'binary').digest('hex')
-    return secrets.share(hexSecret + hashOfSecret, numOfShards, quorum)
+    const shardsHex = secrets.share(hexSecret + hashOfSecret, numOfShards, quorum)
+    return shardsHex.map(shard => Buffer.from(shard, 'utf8').toString('base64'))
   },
 
-  combine: function (shards) {
+  combine: function (shardsBase64) {
+    const shards = shardsBase64.map(shard => Buffer.from(shard, 'base64').toString('utf8'))
     // this could probably be improved by checking the hash before converting to hex
     const hex = secrets.combine(shards)
     const hashOfSecret = hex.slice(-40)
@@ -18,5 +20,14 @@ module.exports = {
     } else {
       return secret
     }
+  },
+  validateShard: function (shardBase64) {
+    const shard = Buffer.from(shardBase64, 'base64').toString('utf8')
+    try {
+      secrets.extractShareComponents(shard)
+    } catch (err) {
+      return false
+    }
+    return true
   }
 }

--- a/secretsWrapper.js
+++ b/secretsWrapper.js
@@ -6,11 +6,23 @@ module.exports = {
     const hexSecret = secrets.str2hex(secret)
     const hashOfSecret = crypto.createHash('sha1').update(secret, 'binary').digest('hex')
     const shardsHex = secrets.share(hexSecret + hashOfSecret, numOfShards, quorum)
-    return shardsHex.map(shard => Buffer.from(shard, 'utf8').toString('base64'))
+  
+    const shardsBase64 = shardsHex.map(shard => {
+      const shardData = shard.slice(3)
+      const shardDataBase64 = Buffer.from(shardData, 'hex').toString('base64')
+      return shard.slice(0,3) + shardDataBase64
+    })
+    console.log('IN', shardsBase64)
+    console.log(shardsHex[0].length, shardsBase64[0].length)
+    return shardsBase64
   },
 
   combine: function (shardsBase64) {
-    const shards = shardsBase64.map(shard => Buffer.from(shard, 'base64').toString('utf8'))
+    const shards = shardsBase64.map(shard => {
+      const shardData = shard.slice(3)
+      const shardDataHex = Buffer.from(shardData, 'base64').toString('hex')
+      return shard.slice(0,3) + shardDataHex
+    })
     // this could probably be improved by checking the hash before converting to hex
     const hex = secrets.combine(shards)
     const hashOfSecret = hex.slice(-40)

--- a/share/async/share.js
+++ b/share/async/share.js
@@ -1,5 +1,4 @@
-const secrets = require('secrets.js-grempe')
-const crypto = require('crypto')
+const secrets = require('../../secretsWrapper')
 
 const PublishRoot = require('../../root/async/publish')
 const PublishRitual = require('../../ritual/async/publish')
@@ -38,9 +37,7 @@ module.exports = function (server) {
 
     const numOfShards = recps.length
 
-    const hexSecret = secrets.str2hex(secret)
-    const hashOfSecret = crypto.createHash('sha1').update(secret, 'binary').digest('hex')
-    const shards = secrets.share(hexSecret + hashOfSecret, numOfShards, quorum)
+    const shards = secrets.share(secret, numOfShards, quorum)
 
     publishRoot(name, (err, root) => {
       if (err) return callback(err)

--- a/share/async/share.js
+++ b/share/async/share.js
@@ -1,4 +1,5 @@
 const secrets = require('secrets.js-grempe')
+const crypto = require('crypto')
 
 const PublishRoot = require('../../root/async/publish')
 const PublishRitual = require('../../ritual/async/publish')
@@ -38,7 +39,8 @@ module.exports = function (server) {
     const numOfShards = recps.length
 
     const hexSecret = secrets.str2hex(secret)
-    const shards = secrets.share(hexSecret, numOfShards, quorum)
+    const hashOfSecret = crypto.createHash('sha1').update(secret, 'binary').digest('hex')
+    const shards = secrets.share(hexSecret + hashOfSecret, numOfShards, quorum)
 
     publishRoot(name, (err, root) => {
       if (err) return callback(err)

--- a/test/secretsWrapper.test.js
+++ b/test/secretsWrapper.test.js
@@ -1,0 +1,34 @@
+
+const { describe } = require('tape-plus')
+const secrets = require('../secretsWrapper')
+
+describe('secretsWrapper', context => {
+  let secret, numRecps, quorum
+
+  context.beforeEach(c => {
+    secret = Math.random().toString(36)
+    numRecps = 5
+    quorum = 3
+  })
+
+  context('secret can be reproduced from quorum of shards', (assert, next) => {
+    try {
+      const shards = secrets.share(secret, numRecps, quorum).slice(2)
+      var result = secrets.combine(shards)
+    } catch (err) {
+      assert.notOk(err, 'does not throw an error')
+    }
+    assert.equal(result, secret, 'secret recovered')
+    next()
+  })
+  context('secret cannot be reproduced from less than quorum of shards', (assert, next) => {
+    try {
+      const shards = secrets.share(secret, numRecps, quorum).slice(3)
+      var result = secrets.combine(shards)
+    } catch (err) {
+      assert.ok(err, 'throws an error')
+    }
+    assert.notEqual(result, secret, 'secret not recovered')
+    next()
+  })
+})


### PR DESCRIPTION
Append an sha1 hash of the secret to itself before sharding.  Check and remove it afterwards.  

This means we can identify when we have successfully recovered a secret without needing to know the quorum.  

It will, however, increase our shard size.