### PR TITLE
Send each shard with an attachment

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -1,0 +1,3 @@
+module.exports = function assert (test, message) {
+  if (!test) throw new Error(message || 'AssertionError')
+}

--- a/lib/unpackLink.js
+++ b/lib/unpackLink.js
@@ -1,0 +1,12 @@
+const assert = require('./assert')
+const { isBlobId } = require('ssb-ref')
+
+module.exports = function unpackLink (link) {
+  const index = link.indexOf('?')
+  const blobId = link.substring(0, index)
+  const blobKey = link.substring(index + 1)
+  assert((blobKey.length), 'Blob not encrypted')
+  // TODO: test for well formed blob key
+  assert((isBlobId(blobId)), 'attachment contains invalid blob reference')
+  return { blobId, blobKey }
+}

--- a/lib/unpackLink.js
+++ b/lib/unpackLink.js
@@ -5,7 +5,7 @@ module.exports = function unpackLink (link) {
   const index = link.indexOf('?')
   const blobId = link.substring(0, index)
   const blobKey = link.substring(index + 1)
-  assert((blobKey.length), 'Blob not encrypted')
+  assert(((index > 0) && (blobKey.length)), 'Blob not encrypted')
   // TODO: test for well formed blob key
   assert((isBlobId(blobId)), 'attachment contains invalid blob reference')
   return { blobId, blobKey }

--- a/shard/async/build.js
+++ b/shard/async/build.js
@@ -1,16 +1,21 @@
 const { box } = require('ssb-keys')
 const { isShard, errorParser } = require('ssb-dark-crystal-schema')
+const { pickBy, identity } = require('lodash')
 // TODO - change to use secretbox from sodium?
 
 module.exports = function buildShard (server) {
-  return function ({ root, shard, recp }, cb) {
-    const content = {
+  return function ({ root, shard, recp, attachment }, cb) {
+    var content = {
       type: 'dark-crystal/shard',
       version: '2.0.0',
       root,
       shard: box(shard, [recp]),
-      recps: [recp, server.id]
+      recps: [recp, server.id],
+      attachment
     }
+
+    // remove falsey values
+    content = pickBy(content, identity)
 
     if (!isShard(content)) return cb(errorParser(content))
 

--- a/shard/async/publish-all.js
+++ b/shard/async/publish-all.js
@@ -5,13 +5,13 @@ const buildShard = require('../async/build')
 const publish = require('../../lib/publish-msg')
 
 module.exports = function (server) {
-  return function publishAll ({ shards, recps, rootId }, callback) {
+  return function publishAll ({ shards, recps, rootId, attachment }, callback) {
     if (!validRecps(recps)) return callback(new Error('shards publishAll: all recps must be valid feedIds', recps))
     if (!isMsg(rootId)) return callback(new Error('shard publishAll: invalid rootId', rootId))
     if (shards.length !== recps.length) return callback(new Error('shard publishAll: need as many shards as recps'))
 
     const opts = shards.map((shard, i) => {
-      return { root: rootId, shard, recp: recps[i] }
+      return { root: rootId, shard, recp: recps[i], attachment }
     })
 
     pull(

--- a/share/async/share.js
+++ b/share/async/share.js
@@ -1,4 +1,4 @@
-const { isFeed, isBlobId, isLink } = require('ssb-ref')
+const { isFeed, isLink } = require('ssb-ref')
 
 const PublishRoot = require('../../root/async/publish')
 const PublishRitual = require('../../ritual/async/publish')
@@ -10,7 +10,6 @@ const isNumber = require('../../lib/isNumber')
 const isString = require('../../lib/isString')
 const isFunction = require('../../lib/isFunction')
 const assert = require('../../lib/assert')
-
 
 module.exports = function (server) {
   const publishRoot = PublishRoot(server)
@@ -35,7 +34,9 @@ module.exports = function (server) {
     if (attachment) {
       if (!isString(attachment.name)) return callback(new Error('data.attachment.name: provide an attachment name'))
       if (!isLink(attachment.link)) return callback(new Error('data.attachment.link: referenced schema does not match'))
-      var { blobId, blobKey } = unpackLink(attachment.link)
+      try {
+        var { blobId, blobKey } = unpackLink(attachment.link)
+      } catch (err) { return callback(err) }
       label = blobKey
       attachment = blobId
     }

--- a/share/async/share.js
+++ b/share/async/share.js
@@ -1,13 +1,16 @@
-const { isFeed, isBlobId } = require('ssb-ref')
+const { isFeed, isBlobId, isLink } = require('ssb-ref')
 
 const PublishRoot = require('../../root/async/publish')
 const PublishRitual = require('../../ritual/async/publish')
 const PublishAllShards = require('../../shard/async/publish-all')
 
 const secrets = require('dark-crystal-secrets')
+const unpackLink = require('../../lib/unpackLink')
 const isNumber = require('../../lib/isNumber')
 const isString = require('../../lib/isString')
 const isFunction = require('../../lib/isFunction')
+const assert = require('../../lib/assert')
+
 
 module.exports = function (server) {
   const publishRoot = PublishRoot(server)
@@ -23,19 +26,22 @@ module.exports = function (server) {
       recps,
       attachment
     } = params
-
-    if (!name && !isString(name)) throw new Error('name must be a string')
-    if (!secret && !isString(secret)) throw new Error('secret must be a string')
-    if (!isNumber(quorum)) throw new Error('quorum must be a number')
-    if (!Array.isArray(recps)) throw new Error('recps must be an array')
-    if (!isFunction(callback)) throw new Error('callback is not a function')
-    if (!label) label = name
-    if (!isString(label)) throw new Error('label must be a string')
+    assert((name && isString(name)), 'name must be a string')
+    assert((secret && isString(secret)), 'secret must be a string')
+    assert((isNumber(quorum)), 'quorum must be a number')
+    assert((Array.isArray(recps)), 'recps must be an array')
+    assert((isFunction(callback)), 'callback must be a function')
 
     if (attachment) {
       if (!isString(attachment.name)) return callback(new Error('data.attachment.name: provide an attachment name'))
-      if (!isBlobId(attachment.link)) return callback(new Error('data.attachment.link: referenced schema does not match'))
+      if (!isLink(attachment.link)) return callback(new Error('data.attachment.link: referenced schema does not match'))
+      var { blobId, blobKey } = unpackLink(attachment.link)
+      label = blobKey
+      attachment = blobId
     }
+
+    if (!label) label = name
+    assert((isString(label)), 'label must be a string')
 
     let feedIds = recps
       .map(recp => typeof recp === 'string' ? recp : recp.link)
@@ -67,7 +73,6 @@ module.exports = function (server) {
         //
         publishAllShards({ shards, recps: recipients, rootId, attachment }, (err, shards) => {
           if (err) return callback(err)
-
           callback(null, {
             root: root,
             ritual: ritual,

--- a/share/async/share.js
+++ b/share/async/share.js
@@ -38,7 +38,7 @@ module.exports = function (server) {
         var { blobId, blobKey } = unpackLink(attachment.link)
       } catch (err) { return callback(err) }
       label = blobKey
-      attachment = blobId
+      attachment = { name: attachment.name, blobId }
     }
 
     if (!label) label = name

--- a/test/share/async/share.test.js
+++ b/test/share/async/share.test.js
@@ -234,7 +234,7 @@ describe('share.async.share', context => {
                   data.shards.map(s => s.value.content.attachment).forEach(attached => (
                     assert.deepEqual(
                       attached,
-                      unpackLink(attachment.link).blobId,
+                      { name: attachment.name, blobId: unpackLink(attachment.link).blobId },
                       'shard contains blob reference'
                     )
                   ))

--- a/test/share/async/share.test.js
+++ b/test/share/async/share.test.js
@@ -115,7 +115,15 @@ describe('share.async.share', context => {
     })
   })
 
-  // TODO: 'throws an error when given unencrypted blob reference'
+  context('throws an error when given an unencrypted blob reference', (assert, next) => {
+    attachment.link = '&ERGA0oJCELz2s4sr47f75iXZComB/2akzZq+IpcuqDs=.sha256'
+    share({ name, secret, quorum, recps, attachment }, (err, data) => {
+      assert.ok(err, 'raises error')
+      assert.notOk(data, 'data is undefined')
+      assert.equal(err.message, 'Blob not encrypted')
+      next()
+    })
+  })
 
   context('publishes a root, a ritual and the shards', (assert, next) => {
     share({ name, secret, quorum, recps }, (err, data) => {

--- a/test/share/async/share.test.js
+++ b/test/share/async/share.test.js
@@ -7,7 +7,7 @@ const Share = require('../../../share/async/share')
 describe('share.async.share', context => {
   let server
   let share
-  let recps, name, secret, quorum
+  let recps, name, secret, quorum, attachment
 
   context.beforeEach(c => {
     server = Server()
@@ -20,6 +20,10 @@ describe('share.async.share', context => {
     name = 'My SBB Dark Crystal'
     secret = Math.random().toString(36)
     quorum = 3
+    attachment = {
+      name: 'gossip.json',
+      link: '&ERGA0oJCELz2s4sr47f75iXZComB/2akzZq+IpcuqDs=.sha256'
+    }
   })
 
   context.afterEach(c => {
@@ -96,6 +100,18 @@ describe('share.async.share', context => {
     })
   })
 
+  context('invalid attachment', (assert, next) => {
+    attachment = { link: 'not a blobId', name: 'name' }
+
+    share({ name, secret, quorum, recps, attachment }, (err, data) => {
+      assert.ok(err, 'raises error')
+      assert.notOk(data, 'data is undefined')
+      assert.equal(err.message, 'data.attachment.link: referenced schema does not match')
+
+      next()
+    })
+  })
+
   context('publishes a root, a ritual and the shards', (assert, next) => {
     share({ name, secret, quorum, recps }, (err, data) => {
       assert.notOk(err, 'error is null')
@@ -133,6 +149,7 @@ describe('share.async.share', context => {
       )
     })
   })
+
   context('publishes a root, a ritual and the shards, when a label is given', (assert, next) => {
     const label = 'Give this key to your nearest and dearest'
     share({ name, secret, quorum, label, recps }, (err, data) => {
@@ -162,6 +179,50 @@ describe('share.async.share', context => {
                 pull.collect((err, shards) => {
                   assert.notOk(err, 'no error')
                   assert.deepEqual(data.shards.map(trim), shards.map(trim), 'publishes a set of shards')
+                  next()
+                })
+              )
+            })
+          )
+        })
+      )
+    })
+  })
+
+  context('Sends the attachment with each shard message', (assert, next) => {
+    share({ name, secret, quorum, recps, attachment }, (err, data) => {
+      assert.notOk(err, 'error is null')
+      assert.ok(data, 'returns the data')
+
+      const pullType = (type) => server.query.read({
+        query: [{
+          $filter: { value: { content: { type } } }
+        }]
+      })
+      console.log(data)
+
+      pull(
+        pullType('dark-crystal/root'),
+        pull.collect((err, roots) => {
+          if (err) console.error(err)
+          assert.deepEqual(trim(data.root), trim(roots[0]), 'publishes a root')
+
+          pull(
+            pullType('dark-crystal/ritual'),
+            pull.collect((err, rituals) => {
+              if (err) console.error(err)
+              assert.deepEqual(trim(data.ritual), trim(rituals[0]), 'publishes a single ritual')
+
+              pull(
+                pullType('dark-crystal/shard'),
+                pull.collect((err, shards) => {
+                  assert.notOk(err, 'no error')
+                  assert.deepEqual(data.shards.map(trim), shards.map(trim), 'publishes a set of shards')
+
+                  data.shards.map(s => s.value.content.attachment).forEach(attached => (
+                    assert.deepEqual(attached, attachment, 'shard contains attachment')
+                  ))
+
                   next()
                 })
               )

--- a/test/share/async/share.test.js
+++ b/test/share/async/share.test.js
@@ -199,7 +199,6 @@ describe('share.async.share', context => {
           $filter: { value: { content: { type } } }
         }]
       })
-      console.log(data)
 
       pull(
         pullType('dark-crystal/root'),


### PR DESCRIPTION
Follow on to https://github.com/blockades/ssb-dark-crystal-schema/pull/20.

Adds capacity to attach a file / blob reference to a shard message. Needed by Patchwork Integration - Phase 1: ssbc/patchwork#952