### PR TITLE
Ephemeral returns updated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -652,6 +652,12 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "buffer-safe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-safe/-/buffer-safe-1.0.0.tgz",
+      "integrity": "sha1-jWcDxAyixv6wAtvtcupqZbNlDi4=",
+      "dev": true
+    },
     "buffer-shims": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
@@ -1891,6 +1897,15 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-bytes": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/file-bytes/-/file-bytes-2.0.3.tgz",
+      "integrity": "sha1-v/3yvwQzH+n208fUQZLpg3WeoCc=",
+      "dev": true,
+      "requires": {
+        "pify": "^2.3.0"
       }
     },
     "file-entry-cache": {
@@ -6454,6 +6469,34 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "skrub": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/skrub/-/skrub-1.4.0.tgz",
+      "integrity": "sha1-si6SkAnW96K6b2xStznbohHMyLc=",
+      "dev": true,
+      "requires": {
+        "buffer-safe": "^1.0.0",
+        "file-bytes": "^2.0.1",
+        "globby": "^6.1.0",
+        "pify": "^2.3.0",
+        "rimraf": "^2.5.2"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -6930,12 +6973,13 @@
       }
     },
     "ssb-ephemeral-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ssb-ephemeral-keys/-/ssb-ephemeral-keys-1.0.1.tgz",
-      "integrity": "sha512-zAvJzbn2SidE2YRewa93QiqruLePKbCplC5uNc5d4dMYgD5X/EwWAeUbU3SU2+5ijgdbtKNZ8omqZgvXeFsJNg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ssb-ephemeral-keys/-/ssb-ephemeral-keys-1.0.2.tgz",
+      "integrity": "sha512-FjQM4sOuESPcvNjrKNBhe0NE9aJTU4faO9bIwM6fF3xVX+qJ3RhsTlK0ZtI5wfcQyRqdgbuVp5+CggRhQbiD3g==",
       "dev": true,
       "requires": {
         "level": "^4.0.0",
+        "skrub": "^1.4.0",
         "sodium-native": "^2.2.3"
       },
       "dependencies": {
@@ -6989,15 +7033,15 @@
           }
         },
         "level-codec": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.0.tgz",
-          "integrity": "sha512-OIpVvjCcZNP5SdhcNupnsI1zo5Y9Vpm+k/F1gfG5kXrtctlrwanisakweJtE0uA0OpLukRfOQae+Fg0M5Debhg==",
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
+          "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==",
           "dev": true
         },
         "level-errors": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.0.tgz",
-          "integrity": "sha512-AmY4HCp9h3OiU19uG+3YWkdELgy05OTP/r23aNHaQKWv8DO787yZgsEuGVkoph40uwN+YdUKnANlrxSsoOaaxg==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+          "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
           "dev": true,
           "requires": {
             "errno": "~0.1.1"
@@ -7056,9 +7100,9 @@
           "dev": true
         },
         "node-abi": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.1.tgz",
-          "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.9.0.tgz",
+          "integrity": "sha512-jmEOvv0eanWjhX8dX1pmjb7oJl1U1oR4FOh0b2GnvALwSYoOdU7sj+kLDSAyjo4pfC9aj/IxkloxdLJQhSSQBA==",
           "dev": true,
           "requires": {
             "semver": "^5.4.1"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "scuttle-testbot": "^1.1.6",
     "ssb-backlinks": "^0.7.3",
-    "ssb-ephemeral-keys": "^1.0.1",
+    "ssb-ephemeral-keys": "^1.0.2",
     "ssb-private": "^0.2.3",
     "ssb-query": "^2.3.0",
     "standard": "^12.0.1",

--- a/test/recover/async/deleteEphemeralKeyPair.test.js
+++ b/test/recover/async/deleteEphemeralKeyPair.test.js
@@ -1,6 +1,7 @@
 const { describe } = require('tape-plus')
 const Server = require('../../testbot')
 const DeleteKeyPair = require('../../../recover/async/deleteEphemeralKeyPair')
+const contextMessage = 'only for testing deletion of an ephemeral keypair'
 
 describe('recover.async.deleteEphemeralKeyPair', context => {
   let server, deleteKeyPair, recp
@@ -23,7 +24,7 @@ describe('recover.async.deleteEphemeralKeyPair', context => {
         if (err) throw err
         deleteKeyPair(rootId, recp, (err) => {
           assert.notOk(err, 'null errors')
-          server.ephemeral.boxMessage('something', ephPublicKey, (err, cipherText) => {
+          server.ephemeral.boxMessage('something', ephPublicKey, contextMessage, (err, cipherText) => {
             if (err) throw err
             server.ephemeral.unBoxMessage({ rootId, recp }, cipherText, null, (err, message) => {
               assert.ok(err, 'throws an error when attempting to use the key')

--- a/test/recover/async/deleteEphemeralKeyPairs.test.js
+++ b/test/recover/async/deleteEphemeralKeyPairs.test.js
@@ -66,7 +66,7 @@ describe('recover.async.deleteEphemeralKeyPairs', context => {
           custodianKeys.forEach(custodianKey => {
             server.ephemeral.boxMessage('something', custodianKey.ephPublicKey, contextMessage, (err, cipherText) => {
               if (err) console.error(err)
-              server.ephemeral.unBoxMessage(custodianKey.dbKey, cipherText, (err, message) => {
+              server.ephemeral.unBoxMessage(custodianKey.dbKey, cipherText, contextMessage, (err, message) => {
                 assert.ok(err, 'throws an error when attempting to use a key')
                 assert.notOk(message, 'returns no message')
               })

--- a/test/recover/async/deleteEphemeralKeyPairs.test.js
+++ b/test/recover/async/deleteEphemeralKeyPairs.test.js
@@ -2,6 +2,7 @@ const { describe } = require('tape-plus')
 const Server = require('../../testbot')
 const DeleteKeyPairs = require('../../../recover/async/deleteEphemeralKeyPairs')
 const pull = require('pull-stream')
+const contextMessage = 'only for testing deletion of ephemeral keypairs'
 
 describe('recover.async.deleteEphemeralKeyPairs', context => {
   let server, deleteKeyPairs, custodians, replies
@@ -44,7 +45,7 @@ describe('recover.async.deleteEphemeralKeyPairs', context => {
     pull(
       pull.values(custodians),
       pull.asyncMap((custodian, cb) => {
-        server.ephemeral.boxMessage('something', testPubKey, (err, cipherText) => {
+        server.ephemeral.boxMessage('something', testPubKey, contextMessage, (err, cipherText) => {
           if (err) console.error(err)
           replies[custodian.id].body = cipherText
           custodian.publish(replies[custodian.id], (err, reply) => {
@@ -63,7 +64,7 @@ describe('recover.async.deleteEphemeralKeyPairs', context => {
         deleteKeyPairs(rootId, (err) => {
           assert.notOk(err, 'null errors')
           custodianKeys.forEach(custodianKey => {
-            server.ephemeral.boxMessage('something', custodianKey.ephPublicKey, (err, cipherText) => {
+            server.ephemeral.boxMessage('something', custodianKey.ephPublicKey, contextMessage, (err, cipherText) => {
               if (err) console.error(err)
               server.ephemeral.unBoxMessage(custodianKey.dbKey, cipherText, (err, message) => {
                 assert.ok(err, 'throws an error when attempting to use a key')


### PR DESCRIPTION
Update ephemeral shard returns to incorporate changes to [ssb-ephemeral-keys](https://github.com/ssbc/ssb-ephemeral-keys)
following [security review](https://github.com/ssbc/ssb-ephemeral-keys/pull/5)

see: https://github.com/blockades/scuttle-dark-crystal/issues/56